### PR TITLE
Service section clarity updates and sermons section styling

### DIFF
--- a/src/app/pages/home-page/sermons-section/sermons-section.component.html
+++ b/src/app/pages/home-page/sermons-section/sermons-section.component.html
@@ -1,15 +1,17 @@
 <div class="sermons-section row">
     <div class="sermons-title">
-        <h2><b>SERMONS</b></h2>
+        <h2 class="sermons-title-text">SERMONS</h2>
     </div>
 
     <div class="sermon-video-container">
-        <iframe class="sermon-video-iframe"
-                src="https://www.youtube.com/embed/videoseries?list=PLEkUPWiPdGnuAzzVS1lGwPPQML71_VmA6" 
-                frameborder="0" 
-                allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" 
-                allowfullscreen>
-        </iframe>
+        <div class="sermon-video-wrapper">
+            <iframe class="sermon-video-iframe"
+                    src="https://www.youtube.com/embed/videoseries?list=PLEkUPWiPdGnuAzzVS1lGwPPQML71_VmA6"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen>
+            </iframe>
+        </div>
     </div>
 
     <div class="sermons-button-container">

--- a/src/app/pages/home-page/sermons-section/sermons-section.component.scss
+++ b/src/app/pages/home-page/sermons-section/sermons-section.component.scss
@@ -2,20 +2,31 @@
     text-align: center;
 }
 .sermons-title {
-    padding-top: 5em;
-    padding-bottom: 3em;
+    padding: 5em 0 2em;
+}
+.sermons-title-text {
+    font-size: 6rem;
+    font-weight: 900;
+    line-height: 0.95;
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.01em;
 }
 .sermon-video-container {
     width: 100%;
-    height: 80vh;
+    padding: 0 7.5rem;
+}
+.sermon-video-wrapper {
+    max-width: 64rem;
+    margin: 0 auto;
+    aspect-ratio: 16 / 9;
 }
 .sermon-video-iframe {
-    width: 80%;
+    width: 100%;
     height: 100%;
-    margin: 0 auto;
 }
 .sermons-button-container {
-    margin-top: 5em;
+    margin-top: 3em;
     margin-bottom: 5em;
 }
 #sermonButton {
@@ -25,14 +36,24 @@
 *  Responsive styles
 */
 @media (max-width: 68rem) {
-    .sermon-video-container {
-        height: 50vh;
-        padding: 0;
+    .sermons-title {
+        padding: 4em 0 1.5em;
     }
-    .sermon-video-iframe {
-        width: 100%;
+    .sermons-title-text {
+        font-size: 4rem;
+    }
+    .sermon-video-container {
+        padding: 0;
     }
     .sermons-button-container {
         padding: 0;
+    }
+}
+@media (max-width: 36rem) {
+    .sermons-title {
+        padding: 3em 0 1.25em;
+    }
+    .sermons-title-text {
+        font-size: 3rem;
     }
 }

--- a/src/app/pages/home-page/service-section/service-section.component.html
+++ b/src/app/pages/home-page/service-section/service-section.component.html
@@ -1,7 +1,7 @@
 <div class="service-section row">
     <div class="col-lg-12 service-details morning-service-details background-image">
         <div class="service-content">
-            <div class="service-pill">ONLINE CHURCH 9AM</div>
+            <div class="service-pill">9AM IN PERSON AND ONLINE</div>
             <h2 class="service-title">SUNDAY<br>SERVICE</h2>
             <p class="service-description">Family gatherings in person and online every Sunday</p>
             <a id="churchOnlineButton" class="btn btn-success btn-green" href="https://www.youtube.com/@NewCreationJHB" target="_blank">

--- a/src/app/pages/home-page/service-section/service-section.component.scss
+++ b/src/app/pages/home-page/service-section/service-section.component.scss
@@ -6,20 +6,22 @@
     padding: 7em 7.5rem;
     min-height: 48rem;
     display: flex;
-    align-items: flex-end;
+    align-items: center;
+    justify-content: center;
 }
 .service-content {
-    text-align: left;
+    text-align: center;
     max-width: 40rem;
 }
 .service-pill {
     display: inline-block;
-    border: 2px solid white;
+    border: 3px solid white;
     border-radius: 999px;
-    padding: 0.5em 1.4em;
-    font-size: 1rem;
+    background-color: rgba(0, 0, 0, 0.35);
+    padding: 0.65em 1.7em;
+    font-size: 1.4rem;
     letter-spacing: 0.15em;
-    font-weight: 500;
+    font-weight: 800;
     margin-bottom: 1rem;
     text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
 }
@@ -55,7 +57,7 @@
         font-size: 4rem;
     }
     .service-pill {
-        font-size: 0.85rem;
+        font-size: 1.15rem;
     }
 }
 @media (max-width: 36rem) {


### PR DESCRIPTION
Reword the service-section pill to "9AM IN PERSON AND ONLINE", make it larger/bolder with a semi-opaque background, and center the hero content over the background image. Restyle the sermons section title to match the service title weight and constrain the embed to a 16:9 wrapper.